### PR TITLE
supporting archivesspace 3.x agent dates

### DIFF
--- a/backend/model/ASDate.rb
+++ b/backend/model/ASDate.rb
@@ -14,15 +14,6 @@ class ASDate < Sequel::Model(:date)
                             event_id
                             digital_object_id
                             digital_object_component_id
-                            related_agents_rlshp_id
-                            agent_person_id
-                            agent_family_id
-                            agent_corporate_entity_id
-                            agent_software_id
-                            name_person_id
-                            name_family_id
-                            name_corporate_entity_id
-                            name_software_id
                             date_type_id
                             label_id|
 

--- a/backend/model/structured_date_range.rb
+++ b/backend/model/structured_date_range.rb
@@ -1,0 +1,19 @@
+class StructuredDateRange < Sequel::Model(:structured_date_range)
+  def before_save
+    if !self.begin_date_standardized && self.begin_date_expression
+      # parse date
+      parsed_date = Timetwister.parse(self.begin_date_expression)
+      # store the parsed values if we were able to parse
+      self.begin_date_standardized = parsed_date[0][:date_start] if parsed_date[0][:date_start]
+    end
+
+    if !self.end_date_standardized && self.end_date_expression
+      # parse date
+      parsed_date = Timetwister.parse(self.end_date_expression)
+      # store the parsed values if we were able to parse
+      self.end_date_standardized = parsed_date[0][:date_start] if parsed_date[0][:date_start]
+    end
+
+    super
+  end
+end

--- a/backend/model/structured_date_single.rb
+++ b/backend/model/structured_date_single.rb
@@ -1,0 +1,11 @@
+class StructuredDateSingle < Sequel::Model(:structured_date_single)
+  def before_save
+    if !self.date_standardized && self.date_expression
+      # parse date
+      parsed_date = Timetwister.parse(self.date_expression)
+      # store the parsed values if we were able to parse
+      self.date_standardized = parsed_date[0][:date_start] if parsed_date[0][:date_start]
+    end
+    super
+  end
+end


### PR DESCRIPTION
ArchivesSpace 3.x includes new models for handling Agent dates (StructuredDateSingle and StructuredDateRange), and no longer uses the old relationships to Agents from ASDate.  This brings timewalk in line with 3.x's models.